### PR TITLE
decompile.py

### DIFF
--- a/decompile.py
+++ b/decompile.py
@@ -125,11 +125,35 @@ if __name__== "__main__":
             print 'Unable to find the standard library'
 
     if args.path:
-        for part in args.path:
-            path.extend(part.split(';'))
+        for parts in args.path:
+            splitBySemi = parts.split(';')
+            for semiPart in splitBySemi:
+                if os.path.isdir(semiPart):
+                    print 'Processing %s directory for JAR files' % semiPart
+                    for dirPath,dirNames,fileNames in os.walk(semiPart):
+                        for fn in fileNames:
+                            if fn.lower().endswith('.jar'):
+                                jarPath = os.path.join(dirPath, fn)
+                                print '  Added %s to path' % fn
+                                path.append(jarPath)
+                else:
+                    path.append(semiPart)
 
-    if args.target.endswith('.jar'):
+    t = args.target
+
+    if t and t.lower().endswith('.jar') and not os.path.isabs(t):
+        for p in path:
+            bn = os.path.basename(p)
+            if bn.lower() == t.lower():
+                args.target = p
+                print 'Target exists at %s' % p
+                break
+    elif t and t.lower().endswith('.jar'):
         path.append(args.target)
+
+    if not os.path.exists(args.out):
+        os.makedirs(args.out)
+        print 'Created output directory %s' % args.out
 
     targets = script_util.findFiles(args.target, args.r, '.class')
     targets = map(script_util.normalizeClassname, targets)


### PR DESCRIPTION
- the 'path' argument can now point to a directory and the decompiler
  will walk the directory, searching for JAR files, appending them to
  the path used for decompilation

- the 'out' argument can now point to a directory that does not yet
  exist, and a new directory will be created if that's the case

- if the target is a JAR file AND it is not an absolute path AND the 
  file name already exists in the path array collected previously then
  the target will defer to absolute path of the previously collected JAR
  file. this makes it so a user simply has to enter the name of a JAR 
  file they know exists in the JAR directory that was traversed earlier