### PR TITLE
Add "-q" flag for quiet operation

### DIFF
--- a/Krakatau/environment.py
+++ b/Krakatau/environment.py
@@ -3,6 +3,7 @@ import os.path
 
 from Krakatau import binUnpacker
 from Krakatau import stdcache
+from Krakatau import script_util
 from Krakatau.classfile import ClassFile
 from Krakatau.error import ClassLoaderError
 
@@ -53,7 +54,7 @@ class Environment(object):
                     pass
 
     def _loadClass(self, name, subclasses):
-        print "Loading", name.encode('utf8')[:70]
+        script_util.printVerbose("Loading " + name.encode('utf8')[:70])
         data = self._searchForFile(name)
 
         if data is None:

--- a/Krakatau/java/javaclass.py
+++ b/Krakatau/java/javaclass.py
@@ -5,6 +5,7 @@ from ..verifier.descriptors import parseFieldDescriptor
 
 from . import ast, ast2, javamethod
 from .reserved import reserved_identifiers
+from Krakatau import script_util
 
 IGNORE_EXCEPTIONS = 0
 
@@ -37,7 +38,7 @@ def _getField(field):
 def _getMethod(method, cb, forbidden_identifiers):
     try:
         graph = cb(method) if method.code is not None else None
-        print 'Decompiling method', method.name.encode('utf8'), method.descriptor.encode('utf8')
+        script_util.printVerbose('Decompiling method {} {}'.format(method.name.encode('utf8'), method.descriptor.encode('utf8')))
         code_ast = javamethod.generateAST(method, graph, forbidden_identifiers)
         return code_ast
     except Exception as e:

--- a/Krakatau/script_util.py
+++ b/Krakatau/script_util.py
@@ -9,6 +9,8 @@ This program is provided as open source under the GNU General Public License.
 See LICENSE.TXT for more details.
 '''
 
+verbose = True
+
 def findFiles(target, recursive, prefix):
     if target.endswith('.jar'):
         with zipfile.ZipFile(target, 'r') as archive:
@@ -107,3 +109,12 @@ def fileDirOut(base_path, suffix):
             f.write(data)
         return out
     return write
+
+def setVerbose(flag):
+    global verbose
+    verbose = flag
+
+def printVerbose(msg):
+    global verbose
+    if verbose == True:
+        print msg

--- a/README.TXT
+++ b/README.TXT
@@ -17,7 +17,7 @@ testing the resulting classes.
 === Decompilation ===
 
 Usage:
-python Krakatau\decompile.py [-nauto] [-path PATH] [-out OUT] [-r] target
+python Krakatau\decompile.py [-nauto] [-path PATH] [-out OUT] [-r] [-q] target
 
 PATH : An optional list of directories, jars, or zipfiles to search for
     classes in. Krakatau will attempt to automatically detect and add the
@@ -28,6 +28,8 @@ OUT : Directory name where source files are to be written. Defaults to the
     current directory
 
 -r : Decompiles all .class files found in the directory target (recursively)
+
+-q : Quiet output; only show warnings or errors
 
 target : Class name or jar name to decompile. If a jar is specified, all
     classes in the jar will be decompiled. If -r is specified, this should
@@ -58,7 +60,7 @@ Warning: Output on Windows uses UNC-style paths, which means that depending on
 === Assembly ===
 
 Usage:
-python Krakatau\assemble.py [-out OUT] [-g] [-jas] [-r] target
+python Krakatau\assemble.py [-out OUT] [-g] [-jas] [-r] [-q] target
 
 OUT : Directory name where class files are to be written. Defaults to the
     current directory
@@ -78,6 +80,8 @@ OUT : Directory name where class files are to be written. Defaults to the
 
 -r : Assembles all .j files found in the directory target (recursively)
 
+-q : Quiet output; only show warnings or errors
+
 target : Name of file to assemble. If -r is specified, this should be a
     directory.
 
@@ -96,12 +100,14 @@ the current directory.
 === Disassembly ===
 
 Usage:
-python Krakatau\disassemble.py [-out OUT] [-r] target
+python Krakatau\disassemble.py [-out OUT] [-r] [-q] target
 
 OUT : File or directory name where source files are to be written. Defaults
     to the current directory
 
 -r : Disassembles all .class files found in the directory target (recursively)
+
+-q : Quiet output; only show warnings or errors
 
 target : Filename or jar name to disassemble. If a jar is specified, all
     classes in the jar will be disassembled. If -r is specified, this should

--- a/assemble.py
+++ b/assemble.py
@@ -19,22 +19,24 @@ def assembleClass(filename, makeLineNumbers, jasmode, debug=0):
     return parse_trees and [assembler.assemble(tree, makeLineNumbers, jasmode, basename) for tree in parse_trees]
 
 if __name__== "__main__":
-    print script_util.copyright
-
     import argparse
     parser = argparse.ArgumentParser(description='Krakatau bytecode assembler')
     parser.add_argument('-out',help='Path to generate files in')
     parser.add_argument('-g', action='store_true', help="Add line number information to the generated class")
     parser.add_argument('-jas', action='store_true', help="Enable Jasmin compatibility mode")
     parser.add_argument('-r', action='store_true', help="Process all files in the directory target and subdirectories")
+    parser.add_argument('-q', action='store_true', help="Quiet output; only show warnings or errors")
     parser.add_argument('target',help='Name of file to assemble')
     args = parser.parse_args()
+
+    script_util.setVerbose(args.q == False)
+    script_util.printVerbose(script_util.copyright)
 
     targets = script_util.findFiles(args.target, args.r, '.j')
     writeout = script_util.fileDirOut(args.out, '.class')
 
     for i, target in enumerate(targets):
-        print 'Processing file {}, {}/{} remaining'.format(target, len(targets)-i, len(targets))
+        script_util.printVerbose('Processing file {}, {}/{} remaining'.format(target, len(targets)-i, len(targets)))
         pairs = assembleClass(target, args.g, args.jas)
 
         # if pairs is None:
@@ -43,4 +45,4 @@ if __name__== "__main__":
 
         for name, data in pairs:
             filename = writeout(name, data)
-            print 'Class written to', filename
+            script_util.printVerbose('Class written to ' + filename)

--- a/decompile.py
+++ b/decompile.py
@@ -77,7 +77,7 @@ def decompileClass(path=[], targets=None, outpath=None, skipMissing=False):
     # random.shuffle(targets)
     with e: #keep jars open
         for i,target in enumerate(targets):
-            print 'processing target {}, {} remaining'.format(target, len(targets)-i)
+            script_util.printVerbose('processing target {}, {} remaining'.format(target, len(targets)-i))
 
             try:
                 c = e.getClass(target)
@@ -95,29 +95,31 @@ def decompileClass(path=[], targets=None, outpath=None, skipMissing=False):
                 source = package + source
 
             filename = writeout(c.name, source)
-            print 'Class written to', filename
-            print time.time() - start_time, ' seconds elapsed'
+            script_util.printVerbose('Class written to ' + filename)
+            script_util.printVerbose('{} seconds elapsed'.format(time.time() - start_time))
             deleteUnusued(c)
 
 if __name__== "__main__":
-    print script_util.copyright
-
     import argparse
     parser = argparse.ArgumentParser(description='Krakatau decompiler and bytecode analysis tool')
     parser.add_argument('-path',action='append',help='Semicolon seperated paths or jars to search when loading classes')
     parser.add_argument('-out',help='Path to generate source files in')
     parser.add_argument('-nauto', action='store_true', help="Don't attempt to automatically locate the Java standard library. If enabled, you must specify the path explicitly.")
     parser.add_argument('-r', action='store_true', help="Process all files in the directory target and subdirectories")
+    parser.add_argument('-q', action='store_true', help="Quiet output; only show warnings or errors")
     parser.add_argument('-skip', action='store_true', help="Skip classes when an error occurs due to missing dependencies")
     parser.add_argument('target',help='Name of class or jar file to decompile')
     args = parser.parse_args()
 
+    script_util.setVerbose(args.q == False)
+    script_util.printVerbose(script_util.copyright)
+
     path = []
     if not args.nauto:
-        print 'Attempting to automatically locate the standard library...'
+        script_util.printVerbose('Attempting to automatically locate the standard library...')
         found = findJRE()
         if found:
-            print 'Found at ', found
+            script_util.printVerbose('Found at ' + found)
             path.append(found)
         else:
             print 'Unable to find the standard library'

--- a/disassemble.py
+++ b/disassemble.py
@@ -19,7 +19,7 @@ def disassembleClass(readTarget, targets=None, outpath=None):
     start_time = time.time()
     # __import__('random').shuffle(targets)
     for i,target in enumerate(targets):
-        print 'processing target {}, {}/{} remaining'.format(target, len(targets)-i, len(targets))
+        script_util.printVerbose('processing target {}, {}/{} remaining'.format(target, len(targets)-i, len(targets)))
 
         data = readTarget(target)
         stream = Krakatau.binUnpacker.binUnpacker(data=data)
@@ -28,19 +28,21 @@ def disassembleClass(readTarget, targets=None, outpath=None):
 
         source = Krakatau.assembler.disassembler.disassemble(class_)
         filename = writeout(class_.name, source)
-        print 'Class written to', filename
-        print time.time() - start_time, ' seconds elapsed'
+        script_util.printVerbose('Class written to ' + filename)
+        script_util.printVerbose('{} seconds elapsed'.format(time.time() - start_time))
 
 if __name__== "__main__":
-    print script_util.copyright
-
     import argparse
     parser = argparse.ArgumentParser(description='Krakatau decompiler and bytecode analysis tool')
     parser.add_argument('-out',help='Path to generate files in')
     parser.add_argument('-r', action='store_true', help="Process all files in the directory target and subdirectories")
+    parser.add_argument('-q', action='store_true', help="Quiet output; only show warnings or errors")
     parser.add_argument('-path',help='Jar to look for class in')
     parser.add_argument('target',help='Name of class or jar file to decompile')
     args = parser.parse_args()
+
+    script_util.setVerbose(args.q == False)
+    script_util.printVerbose(script_util.copyright)
 
     targets = script_util.findFiles(args.target, args.r, '.class')
 


### PR DESCRIPTION
It is very common to invoke assemblers or compilers from a scripted build (e.g. Makefile), and in that case it is desirable to avoid unnecessary console output so that warnings or errors are more apparent to the user.  This patch adds a "-q" option to all three utilities for this purpose.  Sample usage:

```
    OBJS := com/example/class_a.class \
            com/example/class_b.class \
            com/example/class_c.class

    $(OBJS): %.class: %.j
            @echo "  ASM    $@"
            @python assemble.py -q $<

    new.jar: $(OBJS)
            @echo "  JAR    $@"
            @jar cf $@ $^
```

This yields:

```
    $ make new.jar
      ASM    com/example/class_a.class
      ASM    com/example/class_b.class
      ASM    com/example/class_c.class
      JAR    new.jar
    $
```
