### PR TITLE
Fix race condition calling os.makedirs

### DIFF
--- a/Krakatau/script_util.py
+++ b/Krakatau/script_util.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-import platform, os, os.path, zipfile
+import platform, os, os.path, zipfile, errno
 import collections, hashlib
 from functools import partial
 
@@ -102,8 +102,13 @@ def fileDirOut(base_path, suffix):
     def write(cname, data):
         out = makepath(cname)
         dirpath = os.path.dirname(out)
-        if dirpath and not os.path.exists(dirpath):
-            os.makedirs(dirpath)
+
+        try:
+            if dirpath:
+                os.makedirs(dirpath)
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                raise
 
         with open(out,'wb') as f:
             f.write(data)


### PR DESCRIPTION
If multiple assemble.py instances are running concurrently (e.g. from `make -j4`), there is a potential race condition between the call to os.path.exists() and the call to os.makedirs().  Fix this by ignoring EEXIST errors from os.makedirs().

See also: http://stackoverflow.com/questions/16029871/how-to-run-os-mkdir-with-p-option-in-python

This was tested with Python 2.7.3.
