### PR TITLE
Add -rename-classes option

### DIFF
--- a/Krakatau/java/visitor.py
+++ b/Krakatau/java/visitor.py
@@ -12,3 +12,21 @@ class DefaultVisitor(object):
     def className(self, name): return name
     def methodName(self, cls, name, desc): return name
     def fieldName(self, cls, name, desc): return name
+
+
+class RenameClassesVisitor(DefaultVisitor):
+    def __init__(self, targets, name_length):
+        self.targets = targets
+        self.name_length = name_length
+
+        print self.name_length
+
+    def className(self, name):
+        name = name.split('/')
+        if self.should_rename(name[-1]):
+            name[-1] = 'Class_{}'.format(name[-1])
+
+        return '/'.join(name)
+
+    def should_rename(self, name):
+        return self.name_length == 0 or len(name) < self.name_length

--- a/README.TXT
+++ b/README.TXT
@@ -16,7 +16,7 @@ testing the resulting classes.
 === Decompilation ===
 
 Usage:
-python Krakatau\decompile.py [-nauto] [-path PATH] [-out OUT] [-r] [-skip]
+python Krakatau\decompile.py [-nauto] [-path PATH] [-out OUT] [-rename-classes N] [-r] [-skip]
     target
 
 PATH : An optional list of directories, jars, or zipfiles to search for
@@ -28,6 +28,12 @@ PATH : An optional list of directories, jars, or zipfiles to search for
 OUT : Directory name where source files are to be written. Defaults to the
     current directory. If the name ends in .zip or .jar, the output will be a
     zipfile instead.
+
+N   : (Optional). Rename all classes with a name length that is less than N.
+    Use 0 in order to rename all classes regardless of name length.
+    Renaming a class will prefix it with 'Class_'. It is useful with certain
+    obfuscation scheme that rename classes and packages with similar names
+    in order to confuse editors.
 
 -r : Decompiles all .class files found in the directory target (recursively)
 


### PR DESCRIPTION
Add an option to decompile.py that will rename classes with a name length inferior to the number specified. Renamed classes will be prefixed with 'Class_'.

This is useful is certain cases where obfuscation renames classes and packages with similar names, in order to confuse analysts and editors.