### PR TITLE
Add `Module` and `Package` tag types

### DIFF
--- a/Krakatau/classfile.py
+++ b/Krakatau/classfile.py
@@ -13,7 +13,9 @@ cp_structFmts = {3: '>i',
                 12: '>HH',
                 15: '>BH',
                 16: '>H',
-                18: '>HH'}
+                18: '>HH',
+                19: '>H',
+                20: '>H'}
 
 def get_cp_raw(bytestream):
     const_count = bytestream.get('>H')

--- a/Krakatau/constant_pool.py
+++ b/Krakatau/constant_pool.py
@@ -60,9 +60,13 @@ MethodType = cpoolInfo_t('MethodType',16,
 InvokeDynamic = cpoolInfo_t('InvokeDynamic',18,
                 (lambda self,bs_id,nat_id:(bs_id,) + self.getArgs(nat_id)))
 
+Module = cpoolInfo_t('Module',19, (lambda self,unkn: unkn))
+
+Package = cpoolInfo_t('Package',20, (lambda self,unkn: unkn))
+
 cpoolTypes = [Utf8, Class, NameAndType, Field, Method, InterfaceMethod,
               String, Int, Long, Float, Double,
-              MethodHandle, MethodType, InvokeDynamic]
+              MethodHandle, MethodType, InvokeDynamic, Module, Package]
 name2Type = {t.name:t for t in cpoolTypes}
 tag2Type = {t.tag:t for t in cpoolTypes}
 


### PR DESCRIPTION
[module-info.zip](https://github.com/Storyyeller/Krakatau/files/10871695/module-info.zip) (taken from Google Closure Compiler jar (`compiler_uberjar_deploy.jar`) produced by CI (not the downloads on Maven) )

https://github.com/openjdk/jdk/blob/72de24e59a80a38ea4ea6a8a3f966f555987ac86/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ClassConstants.java
https://github.com/openjdk/jdk/blob/72de24e59a80a38ea4ea6a8a3f966f555987ac86/src/java.base/share/native/include/classfile_constants.h.template
https://github.com/openjdk/jdk/blob/72de24e59a80a38ea4ea6a8a3f966f555987ac86/src/hotspot/share/classfile/classFileParser.cpp#L356-L366

It seems that the value is unused.

Haven't tested it on a full jar, but running it on the file provided (even with setting the classpath to the jar it is taken from) results in `ClassNotFoundException: //module-info`